### PR TITLE
chore: mention REUSE tool in README

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -2,11 +2,7 @@ Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: bayesian-network-builder
 Upstream-Contact: Giancarlo Frison <giancarlo.frison@sap.com>
 Source: https://github.com/sap/bayesian-network-builder
-Files:
-Copyright: SAP SE or an SAP affiliate company and contributors
+
+Files: README.md
+Copyright: SAP SE or an SAP affiliate company and bayesian-network-builder contributors
 License: Apache-2.0
-# Sample paragraph, commented out:
-#
-# Files: src/*
-# Copyright: $YEAR $NAME <$CONTACT>
-# License: ...

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 <img src="https://raw.githubusercontent.com/SAP/bayesian-network-builder/master/docs/logo.png" width="100"> Bayesian Network Builder 
 =====
 
+[![REUSE status](https://api.reuse.software/badge/github.com/SAP/bayesian-network-builder)](https://api.reuse.software/info/github.com/SAP/bayesian-network-builder)
 
 A [Bayesian Belief Network](https://en.wikipedia.org/wiki/Bayesian_network) (BBN), or simply Bayesian Network, is a statistical model used to describe the [conditional dependencies](https://en.wikipedia.org/wiki/Conditional_dependence) between different random variables.
 
@@ -107,5 +108,6 @@ If you're interested please check these two important documents:
 
 Contact me under [Giancarlo Frison](mailto:giancarlo.frison@sap.com)
 
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and bayesian-network-builder contributors
-SPDX-License-Identifier: Apache-2.0
+## Licensing 
+
+Copyright 2020-2021 SAP SE or an SAP affiliate company and bayesian-network-builder contributors. Please see our [LICENSE](LICENSE) for copyright and license information. Detailed information including third-party components and their licensing/copyright information is available [via the REUSE tool](https://api.reuse.software/info/github.com/SAP/bayesian-network-builder).


### PR DESCRIPTION
In line with SAP OSPO requirements, this PR adds the REUSE Tool links to the README

**Notes:** 
- Please register the repository with the REUSE Tool to complete the integration (see #5 and #6)

Fixes #4